### PR TITLE
Use common entity service for config entities

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -6764,7 +6764,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/angular/src/app/claims/claims.service.ts
+++ b/angular/src/app/claims/claims.service.ts
@@ -1,55 +1,15 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
-import { pluck } from 'rxjs/operators';
 
-import { environment } from '../../environments/environment';
-
-const headers = new HttpHeaders({ 'Content-Type': 'application/json', 'charset': 'UTF-8' });
+import {ConfigEntityService} from '../shared/ConfigEntityService';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ClaimService implements EntityService {
+export class ClaimService extends ConfigEntityService {
 
-  constructor(private http: HttpClient) { }
-
-  get(params?): Observable<any[]> {
-    params = params || {};
-    params.persona = 'nci_researcher';
-
-    return this.http.get<any[]>(environment.ddapApiUrl + '/config', { params })
-      .pipe(
-        pluck('trustedClaims')
-      );
+  constructor(http: HttpClient) {
+    super(http, 'trustedClaims');
   }
 
-  save(claimChange: any): Observable<any> {
-    const params = {
-      persona: 'nci_researcher',
-    };
-    const claimtName = claimChange.item.name;
-
-    return this.http.post(
-      environment.ddapApiUrl + '/config/' + claimtName,
-      claimChange,
-      { params, headers }
-    );
-  }
-
-  update(claim: any): Observable<any> {
-    const params = {
-      persona: 'nci_researcher',
-    };
-    const claimtName = claim.name;
-    const claimChange = {
-      item: claim,
-    };
-
-    return this.http.patch(
-      environment.ddapApiUrl + '/config/' + claimtName,
-      claimChange,
-      { params, headers }
-    );
-  }
 }

--- a/angular/src/app/clients/client.service.ts
+++ b/angular/src/app/clients/client.service.ts
@@ -1,55 +1,15 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
-import { pluck } from 'rxjs/operators';
 
-import { environment } from '../../environments/environment';
-
-const headers = new HttpHeaders({ 'Content-Type': 'application/json', 'charset': 'UTF-8' });
+import {ConfigEntityService} from '../shared/ConfigEntityService';
 
 @Injectable({
   providedIn: 'root',
 })
-export class ClientService implements EntityService {
+export class ClientService extends ConfigEntityService {
 
-  constructor(private http: HttpClient) { }
-
-  get(params?): Observable<any[]> {
-    params = params || {};
-    params.persona = 'nci_researcher';
-
-    return this.http.get<any[]>(environment.ddapApiUrl + '/config', { params })
-      .pipe(
-        pluck('clients')
-      );
+  constructor(http: HttpClient) {
+    super(http, 'clients');
   }
 
-  save(clientChange: any): Observable<any> {
-    const params = {
-      persona: 'nci_researcher',
-    };
-    const clientName = clientChange.item.name;
-
-    return this.http.post(
-      environment.ddapApiUrl + '/config/' + clientName,
-      clientChange,
-      { params, headers }
-    );
-  }
-
-  update(client: any): Observable<any> {
-    const params = {
-      persona: 'nci_researcher',
-    };
-    const clientName = client.name;
-    const clientChange = {
-      item: client,
-    };
-
-    return this.http.patch(
-      environment.ddapApiUrl + '/config/' + clientName,
-      clientChange,
-      { params, headers }
-    );
-  }
 }

--- a/angular/src/app/rules/rule.service.ts
+++ b/angular/src/app/rules/rule.service.ts
@@ -1,55 +1,14 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
-import { pluck } from 'rxjs/operators';
 
-import { environment } from '../../environments/environment';
-
-const headers = new HttpHeaders({ 'Content-Type': 'application/json', 'charset': 'UTF-8' });
+import {ConfigEntityService} from '../shared/ConfigEntityService';
 
 @Injectable({
   providedIn: 'root',
 })
-export class RuleService {
+export class RuleService extends ConfigEntityService {
 
-  constructor(private http: HttpClient) { }
-
-  get(params?): Observable<any[]> {
-    params = params || {};
-    params.persona = 'nci_researcher';
-
-    return this.http.get<any[]>(environment.ddapApiUrl + '/config', { params })
-      .pipe(
-        pluck('rules')
-      );
-  }
-
-  save(ruleChange: any): Observable<any> {
-    const params = {
-      persona: 'nci_researcher',
-    };
-    const ruleName = ruleChange.item.name;
-
-    return this.http.post(
-      environment.ddapApiUrl + '/config/' + ruleName,
-      ruleChange,
-      { params, headers }
-    );
-  }
-
-  update(rule: any): Observable<any> {
-    const params = {
-      persona: 'nci_researcher',
-    };
-    const ruleName = rule.name;
-    const ruleChange = {
-      item: rule,
-    };
-
-    return this.http.patch(
-      environment.ddapApiUrl + '/config/' + ruleName,
-      ruleChange,
-      { params, headers }
-    );
+  constructor(http: HttpClient) {
+    super(http, 'rules');
   }
 }

--- a/angular/src/app/shared/ConfigEntityService.ts
+++ b/angular/src/app/shared/ConfigEntityService.ts
@@ -1,0 +1,53 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { mergeMap, pluck } from 'rxjs/operators';
+
+import { environment } from '../../environments/environment';
+
+const headers = new HttpHeaders({ 'Content-Type': 'application/json', 'charset': 'UTF-8' });
+
+export class ConfigEntityService implements EntityService {
+
+  constructor(protected http: HttpClient, protected entityName: string) { }
+
+  get(params?): any {
+    params = params || {};
+    params.persona = 'nci_researcher';
+
+    return this.http.get<any[]>(environment.ddapApiUrl + '/config', { params })
+      .pipe(
+        pluck(this.entityName)
+      );
+  }
+
+  save(dto: any): any {
+    const params = {
+      persona: 'nci_researcher',
+    };
+    const id = dto.name;
+
+    return this.http.get<any[]>(environment.ddapApiUrl + '/config', { params })
+      .pipe(
+        mergeMap((config: any) => {
+          config[this.entityName][id] = dto;
+          return this.updateConfig(config);
+        })
+      );
+  }
+
+  update(dto: any): any {
+      return this.save(dto);
+  }
+
+  private updateConfig(config: object): any {
+    const params = {
+      persona: 'nci_researcher',
+    };
+
+    return this.http.put(
+      environment.ddapApiUrl + '/config',
+      { item: config },
+      { params, headers }
+    );
+  }
+
+}


### PR DESCRIPTION
Few things we will need to resolve:
1. refresh view after edit
2. currently every entity has `name` which serves kind of as `id`, this makes things complicated when user edits `name` property. Currently it spawns a new object.
3. Add should transit to list of entities after success, or/and provide feedback