### PR TITLE
DISCO-1896 Respond to each request with an authentication indicator

### DIFF
--- a/src/main/java/com/dnastack/ddapfrontend/proxy/SetBearerTokenFromCookieGatewayFilterFactory.java
+++ b/src/main/java/com/dnastack/ddapfrontend/proxy/SetBearerTokenFromCookieGatewayFilterFactory.java
@@ -17,41 +17,25 @@
 
 package com.dnastack.ddapfrontend.proxy;
 
-import com.dnastack.ddapfrontend.header.XForwardUtil;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
-import org.springframework.http.HttpCookie;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Base64;
 import java.util.Optional;
 
+import static com.dnastack.ddapfrontend.security.UserTokenStatusFilter.extractDamToken;
 import static java.lang.String.format;
 
 @Slf4j
 @Component
 public class SetBearerTokenFromCookieGatewayFilterFactory extends AbstractGatewayFilterFactory {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
     @Override
     public GatewayFilter apply(Object config) {
         return (exchange, chain) -> {
             final ServerHttpRequest request = exchange.getRequest();
-            final ServerHttpResponse response = exchange.getResponse();
 
             Optional<String> extractedToken = extractDamToken(request);
 
@@ -62,15 +46,6 @@ public class SetBearerTokenFromCookieGatewayFilterFactory extends AbstractGatewa
                         .header("Authorization", format("Bearer %s", token))
                         .build();
 
-                if (isTokenExpired(token)) {
-                    log.info("Clearing expired token cookie");
-                    final String requestUrl = XForwardUtil.getExternalPath(request, "/");
-                    final String cookieHost = URI.create(requestUrl).getHost();
-
-                    // Side effect! This adds a set-cookie header to the response.
-                    response.addCookie(clearDamToken(cookieHost));
-                }
-
                 return chain.filter(exchange.mutate()
                         .request(requestWithDamToken)
                         .build());
@@ -79,81 +54,5 @@ public class SetBearerTokenFromCookieGatewayFilterFactory extends AbstractGatewa
             }
 
         };
-    }
-
-    private static boolean isTokenExpired(String token) {
-        String[] jwtParts = token.split("\\.", -1);
-        if (jwtParts.length != 3) {
-            log.info("Treating malformed token cookie as expired ({} parts != 3", jwtParts.length);
-            return true;
-        }
-
-        String jsonBody;
-        try {
-            jsonBody = new String(Base64.getUrlDecoder().decode(jwtParts[1]), StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
-            log.info("Treating malformed token cookie as expired (couldn't base64 decode body)", e);
-            return true;
-        }
-
-        JwtExpiration decodedBody;
-        try {
-            decodedBody = objectMapper.readValue(jsonBody, JwtExpiration.class);
-        } catch (IOException e) {
-            log.info("Treating malformed token cookie as expired (couldn't JSON decode body)", e);
-            return true;
-        }
-
-        return decodedBody.getExp() < Instant.now().getEpochSecond();
-    }
-
-    /**
-     * Extracts the user's DAM authorization token from the given request, which carries it in an
-     * encrypted cookie.
-     *
-     * @param request the request that originated from the user and probably contains the encrypted DAM token.
-     * @return A string that can be used as a bearer token in a request to DAM, or {@code Optional.empty}
-     * if the given request doesn't contain a usable token.
-     */
-    public static Optional<String> extractDamToken(ServerHttpRequest request) {
-        return Optional.ofNullable(request.getCookies().getFirst("user_token"))
-                .map(HttpCookie::getValue);
-    }
-
-    /**
-     * Encrypts the given token, which is valid authorization to call in to the DAM, and returns the result
-     * as a cookie to be set for the given hostname.
-     *
-     * @param token The token as usable for calling DAM
-     * @param cookieHost The host the returned cookie should target. Should usually point to this DDAP server, since we
-     *                  are the only ones who can decrypt the cookie's contents.
-     * @return a cookie that should be sent to the user's browser.
-     */
-    public static ResponseCookie packageDamToken(String token, String cookieHost) {
-        return ResponseCookie.from("user_token", token)
-                .domain(cookieHost)
-                .path("/")
-                .build();
-    }
-
-    /**
-     * Produces a cookie that, when set for the given hostname, clears the user's DAM authorization.
-     *
-     * @param cookieHost The host the returned cookie should target. Should usually point to this DDAP server, and
-     *                   should match the cookieHost passed to {@link #packageDamToken(String, String)} on a previous
-     *                   request.
-     * @return a cookie that should be sent to the user's browser to clear their DAM token.
-     */
-    public static ResponseCookie clearDamToken(String cookieHost) {
-        return ResponseCookie.from("user_token", "expired")
-                .domain(cookieHost)
-                .path("/")
-                .maxAge(Duration.ZERO)
-                .build();
-    }
-
-    @Data
-    private static class JwtExpiration {
-        long exp;
     }
 }

--- a/src/main/java/com/dnastack/ddapfrontend/route/BeaconResource.java
+++ b/src/main/java/com/dnastack/ddapfrontend/route/BeaconResource.java
@@ -9,7 +9,7 @@ import com.dnastack.ddapfrontend.client.dam.DamResource;
 import com.dnastack.ddapfrontend.client.dam.DamResourceList;
 import com.dnastack.ddapfrontend.client.dam.DamView;
 import com.dnastack.ddapfrontend.model.BeaconRequestModel;
-import com.dnastack.ddapfrontend.proxy.SetBearerTokenFromCookieGatewayFilterFactory;
+import com.dnastack.ddapfrontend.security.UserTokenStatusFilter;
 import lombok.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -20,7 +20,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -66,7 +69,7 @@ class BeaconResource {
             ServerHttpRequest request) {
 
         // find beacons under resourceId in DAM config
-        Optional<String> damToken = SetBearerTokenFromCookieGatewayFilterFactory.extractDamToken(request);
+        Optional<String> damToken = UserTokenStatusFilter.extractDamToken(request);
         if (!damToken.isPresent()) {
             return Flux.error(new IllegalArgumentException("Authorization is required")); // TODO make this return a 401
         }

--- a/src/main/java/com/dnastack/ddapfrontend/route/Router.java
+++ b/src/main/java/com/dnastack/ddapfrontend/route/Router.java
@@ -1,6 +1,6 @@
 package com.dnastack.ddapfrontend.route;
 
-import com.dnastack.ddapfrontend.proxy.SetBearerTokenFromCookieGatewayFilterFactory;
+import com.dnastack.ddapfrontend.security.UserTokenStatusFilter;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -149,7 +149,7 @@ public class Router {
     private Mono<ServerResponse> successfulUserTokenResponse(ServerRequest request, String token) {
         final URI redirectUri = URI.create(getExternalPath(request, "/data"));
         final String publicHost = redirectUri.getHost();
-        final ResponseCookie cookie = SetBearerTokenFromCookieGatewayFilterFactory.packageDamToken(token, publicHost);
+        final ResponseCookie cookie = UserTokenStatusFilter.packageDamToken(token, publicHost);
         return temporaryRedirect(redirectUri).cookie(cookie)
                                              .build();
     }

--- a/src/main/java/com/dnastack/ddapfrontend/security/UserTokenStatusFilter.java
+++ b/src/main/java/com/dnastack/ddapfrontend/security/UserTokenStatusFilter.java
@@ -1,0 +1,150 @@
+package com.dnastack.ddapfrontend.security;
+
+import com.dnastack.ddapfrontend.header.XForwardUtil;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * Inspects every inbound request and affects the response in the following two ways:
+ * <ol>
+ * <li>Adds a {@code x-ddap-auth-valid: {true|false}} response header indicating whether or not a valid user token
+ * was presented with the request</li>
+ * <li>If the user's auth token is malformed, stale-dated, or has a bad signature, adds a {@code set-cookie} header
+ * that removes the cookie carrying the user's auth token</li>
+ * </ol>
+ */
+@Slf4j
+@Component
+public class UserTokenStatusFilter implements WebFilter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+
+        final ServerHttpRequest originalRequest = exchange.getRequest();
+        final ServerHttpResponse mutableResponse = exchange.getResponse();
+
+        Optional<String> extractedToken = extractDamToken(originalRequest);
+        boolean haveValidAuth;
+
+        if (extractedToken.isPresent()) {
+            final String token = extractedToken.get();
+
+            if (isTokenExpired(token)) {
+                log.info("Clearing expired token cookie");
+                final String requestUrl = XForwardUtil.getExternalPath(originalRequest, "/");
+                final String cookieHost = URI.create(requestUrl).getHost();
+                mutableResponse.addCookie(clearDamToken(cookieHost));
+                haveValidAuth = false;
+            } else {
+                haveValidAuth = true;
+            }
+
+        } else {
+            haveValidAuth = false;
+        }
+
+        mutableResponse.getHeaders().add("X-DDAP-Authenticated", Boolean.toString(haveValidAuth));
+
+        return chain.filter(exchange);
+    }
+
+
+    private static boolean isTokenExpired(String token) {
+        String[] jwtParts = token.split("\\.", -1);
+        if (jwtParts.length != 3) {
+            log.info("Treating malformed token cookie as expired ({} parts != 3", jwtParts.length);
+            return true;
+        }
+
+        String jsonBody;
+        try {
+            jsonBody = new String(Base64.getUrlDecoder().decode(jwtParts[1]), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            log.info("Treating malformed token cookie as expired (couldn't base64 decode body)", e);
+            return true;
+        }
+
+        JwtExpiration decodedBody;
+        try {
+            decodedBody = objectMapper.readValue(jsonBody, JwtExpiration.class);
+        } catch (IOException e) {
+            log.info("Treating malformed token cookie as expired (couldn't JSON decode body)", e);
+            return true;
+        }
+
+        return decodedBody.getExp() < Instant.now().getEpochSecond();
+    }
+
+    /**
+     * Extracts the user's DAM authorization token from the given request, which carries it in an
+     * encrypted cookie.
+     *
+     * @param request the request that originated from the user and probably contains the encrypted DAM token.
+     * @return A string that can be used as a bearer token in a request to DAM, or {@code Optional.empty}
+     * if the given request doesn't contain a usable token.
+     */
+    public static Optional<String> extractDamToken(ServerHttpRequest request) {
+        return Optional.ofNullable(request.getCookies().getFirst("user_token"))
+                .map(HttpCookie::getValue);
+    }
+
+    /**
+     * Encrypts the given token, which is valid authorization to call in to the DAM, and returns the result
+     * as a cookie to be set for the given hostname.
+     *
+     * @param token      The token as usable for calling DAM
+     * @param cookieHost The host the returned cookie should target. Should usually point to this DDAP server, since we
+     *                   are the only ones who can decrypt the cookie's contents.
+     * @return a cookie that should be sent to the user's browser.
+     */
+    public static ResponseCookie packageDamToken(String token, String cookieHost) {
+        return ResponseCookie.from("user_token", token)
+                .domain(cookieHost)
+                .path("/")
+                .build();
+    }
+
+    /**
+     * Produces a cookie that, when set for the given hostname, clears the user's DAM authorization.
+     *
+     * @param cookieHost The host the returned cookie should target. Should usually point to this DDAP server, and
+     *                   should match the cookieHost passed to {@link #packageDamToken(String, String)} on a previous
+     *                   request.
+     * @return a cookie that should be sent to the user's browser to clear their DAM token.
+     */
+    public static ResponseCookie clearDamToken(String cookieHost) {
+        return ResponseCookie.from("user_token", "expired")
+                .domain(cookieHost)
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .build();
+    }
+
+    @Data
+    private static class JwtExpiration {
+        long exp;
+    }
+
+}

--- a/src/test/java/com/dnastack/ddapfrontend/proxy/SetBearerTokenFromCookieGatewayFilterFactoryTest.java
+++ b/src/test/java/com/dnastack/ddapfrontend/proxy/SetBearerTokenFromCookieGatewayFilterFactoryTest.java
@@ -1,28 +1,20 @@
 package com.dnastack.ddapfrontend.proxy;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.HttpCookie;
-import org.springframework.http.ResponseCookie;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
 
 import java.net.URI;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -38,15 +30,26 @@ public class SetBearerTokenFromCookieGatewayFilterFactoryTest {
     }
 
     @Test
-    public void shouldTreatMalformedJwtAsExpired() {
-        assertResponseExpiresCookie("not_enough_sections");
-        assertResponseExpiresCookie("not!.even!.base64!");
-        assertResponseExpiresCookie("not.aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g_dj1vSGc1U0pZUkhBMA.json");
-    }
+    public void shouldCopyUserTokenCookieAsBearerTokenInOnwardRequest() {
+        // given
+        String cookieToken = "attach this as a bearer token and everyone's happy!";
+        URI originalUri = URI.create("http://example.com/anything");
 
-    @Test
-    public void shouldNotRemoveValidJwtCookie() throws Exception {
-        assertResponseLeavesCookieAlone(fakeUserToken(Instant.now().plusSeconds(10)));
+        ServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("http://example.com/anything")
+                        .cookie(new HttpCookie("user_token", cookieToken)).build());
+
+        GatewayFilterChain chain = mock(GatewayFilterChain.class);
+
+        // when
+        filter.filter(exchange, chain);
+
+        // then
+        ArgumentCaptor<ServerWebExchange> result = ArgumentCaptor.forClass(ServerWebExchange.class);
+        verify(chain).filter(result.capture());
+        ServerHttpRequest onwardRequest = result.getValue().getRequest();
+        assertThat(onwardRequest.getURI(), is(originalUri));
+        assertThat(onwardRequest.getHeaders().getFirst("Authorization"), is("Bearer " + cookieToken));
     }
 
     @Test
@@ -69,50 +72,4 @@ public class SetBearerTokenFromCookieGatewayFilterFactoryTest {
         assertThat(onwardRequestUri, is(originalUri));
     }
 
-    private void assertResponseExpiresCookie(String jwtValue) {
-        ResponseCookie responseCookie = runFilterAndExtractResponseCookie(jwtValue);
-        assertThat("Expected a 'user_token' cookie in the response",
-                responseCookie, notNullValue());
-        assertThat(responseCookie.getValue(), is("expired"));
-        assertThat(responseCookie.getMaxAge(), is(Duration.ZERO));
-    }
-
-    private void assertResponseLeavesCookieAlone(String jwtValue) {
-        ResponseCookie responseCookie = runFilterAndExtractResponseCookie(jwtValue);
-        assertThat(responseCookie, nullValue());
-    }
-
-    private ResponseCookie runFilterAndExtractResponseCookie(String jwtValue) {
-        // given
-        ServerWebExchange exchange = MockServerWebExchange.from(
-                MockServerHttpRequest.get("http://example.com/anything")
-                        .cookie(new HttpCookie("user_token", jwtValue)).build());
-
-        GatewayFilterChain chain = mock(GatewayFilterChain.class);
-
-        // when
-        filter.filter(exchange, chain);
-
-        // then
-        ArgumentCaptor<ServerWebExchange> result = ArgumentCaptor.forClass(ServerWebExchange.class);
-        verify(chain).filter(result.capture());
-        return result.getValue().getResponse().getCookies().getFirst("user_token");
-    }
-
-    private String fakeUserToken(Instant exp) throws JsonProcessingException {
-        ObjectMapper jsonMapper = new ObjectMapper();
-        Base64.Encoder b64Encoder = Base64.getUrlEncoder().withoutPadding();
-
-        Map<String, Object> header = new HashMap<>();
-        header.put("typ", "JWT");
-        header.put("alg", "none");
-
-        Map<String, Object> body = new HashMap<>();
-        body.put("exp", exp.getEpochSecond());
-
-        return b64Encoder.encodeToString(jsonMapper.writeValueAsBytes(header)) +
-                "." +
-                b64Encoder.encodeToString(jsonMapper.writeValueAsBytes(body)) +
-                ".";
-    }
 }

--- a/src/test/java/com/dnastack/ddapfrontend/security/UserTokenStatusFilterTest.java
+++ b/src/test/java/com/dnastack/ddapfrontend/security/UserTokenStatusFilterTest.java
@@ -1,0 +1,114 @@
+package com.dnastack.ddapfrontend.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class UserTokenStatusFilterTest {
+
+    UserTokenStatusFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        filter = new UserTokenStatusFilter();
+    }
+
+    @Test
+    public void shouldTreatMalformedJwtAsExpired() {
+        assertResponseExpiresCookie("not_enough_sections");
+        assertResponseExpiresCookie("not!.even!.base64!");
+        assertResponseExpiresCookie("not.aHR0cHM6Ly93d3cueW91dHViZS5jb20vd2F0Y2g_dj1vSGc1U0pZUkhBMA.json");
+    }
+
+    @Test
+    public void shouldNotRemoveValidJwtCookie() throws Exception {
+        assertResponseLeavesCookieAlone(fakeUserToken(Instant.now().plusSeconds(10)));
+    }
+
+    @Test
+    public void shouldPassThroughRequestsWithoutCookie() {
+        // given
+        URI originalUri = URI.create("http://example.com/anything");
+
+        ServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get(originalUri.toString()).build());
+
+        WebFilterChain chain = mock(WebFilterChain.class);
+
+        // when
+        filter.filter(exchange, chain);
+
+        // then
+        ArgumentCaptor<ServerWebExchange> result = ArgumentCaptor.forClass(ServerWebExchange.class);
+        verify(chain).filter(result.capture());
+        URI onwardRequestUri = result.getValue().getRequest().getURI();
+        assertThat(onwardRequestUri, is(originalUri));
+    }
+
+    private void assertResponseExpiresCookie(String jwtValue) {
+        ResponseCookie responseCookie = runFilterAndExtractResponseCookie(jwtValue);
+        assertThat("Expected a 'user_token' cookie in the response",
+                responseCookie, notNullValue());
+        assertThat(responseCookie.getValue(), is("expired"));
+        assertThat(responseCookie.getMaxAge(), is(Duration.ZERO));
+    }
+
+    private void assertResponseLeavesCookieAlone(String jwtValue) {
+        ResponseCookie responseCookie = runFilterAndExtractResponseCookie(jwtValue);
+        assertThat(responseCookie, nullValue());
+    }
+
+    private ResponseCookie runFilterAndExtractResponseCookie(String jwtValue) {
+        // given
+        ServerWebExchange exchange = MockServerWebExchange.from(
+                MockServerHttpRequest.get("http://example.com/anything")
+                        .cookie(new HttpCookie("user_token", jwtValue)).build());
+
+        WebFilterChain chain = mock(WebFilterChain.class);
+
+        // when
+        filter.filter(exchange, chain);
+
+        // then
+        ArgumentCaptor<ServerWebExchange> result = ArgumentCaptor.forClass(ServerWebExchange.class);
+        verify(chain).filter(result.capture());
+        return result.getValue().getResponse().getCookies().getFirst("user_token");
+    }
+
+    private String fakeUserToken(Instant exp) throws JsonProcessingException {
+        ObjectMapper jsonMapper = new ObjectMapper();
+        Base64.Encoder b64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+        Map<String, Object> header = new HashMap<>();
+        header.put("typ", "JWT");
+        header.put("alg", "none");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("exp", exp.getEpochSecond());
+
+        return b64Encoder.encodeToString(jsonMapper.writeValueAsBytes(header)) +
+                "." +
+                b64Encoder.encodeToString(jsonMapper.writeValueAsBytes(body)) +
+                ".";
+    }
+}


### PR DESCRIPTION
This includes a refactoring that moves the cookie handling logic out of `SetBearerTokenFromCookieGatewayFilterFactory`, which only participates in requests that are being forwarded to DAM, to the new `UserTokenStatusFilter`, which participates in all DDAP requests. I chose to add this new global filter because we want to keep the UI in-the-know about the user's authentication status.

Question: should we pull more data out of the token and stuff it in the header? Perhaps the user's name, so the Angular app can display it?