### PR TITLE
DISCO-2078 Make data boxes width more uniform

### DIFF
--- a/angular/src/app/data/data-list/data-list.component.html
+++ b/angular/src/app/data/data-list/data-list.component.html
@@ -9,11 +9,11 @@
     <mat-card-title>{{ entity.dto.ui.label || 'Unknown' }}</mat-card-title>
     <mat-card-subtitle>{{ entity.dto.ui.description || 'Unknown' }}</mat-card-subtitle>
   </mat-card-header>
-  <div class="ddap-data-image">
-    <img mat-card-image
-         [src]="[entity.dto.ui.imageUrl || randomImageRetriever.getPathToFixedRandomImage(entity.dto.ui.label)]"
-         alt="Photo">
-  </div>
+
+  <img mat-card-image
+       [src]="[entity.dto.ui.imageUrl || randomImageRetriever.getPathToFixedRandomImage(entity.dto.ui.label)]"
+       alt="Photo">
+
   <mat-card-content>
     <p>{{ entity.dto.ui.description || 'Unknown' }}</p>
   </mat-card-content>

--- a/angular/src/app/data/data-list/data-list.component.scss
+++ b/angular/src/app/data/data-list/data-list.component.scss
@@ -6,18 +6,14 @@
   min-width: 20rem;
   width: calc(30% + 4rem);
   max-width: 30rem;
-  height: 20rem;
+  min-height: 20rem;
   display: inline-block;
   margin-right: 1rem;
   margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
 
   mat-card-title {
     word-break: break-all;
-  }
-
-  .ddap-data-image {
-    min-width: 20rem;
-    min-height: 10rem;
   }
 
   img {


### PR DESCRIPTION
I've picked the media query width just by trial and error to make the page look good. But we should probably refactor them out in case we want to support mobile environments (I don't know if we are).