### PR TITLE
DISCO-2091 Log out sends you to the current realm in IC

### DIFF
--- a/angular/src/app/layout/layout.component.html
+++ b/angular/src/app/layout/layout.component.html
@@ -21,7 +21,7 @@
                      data-se="nav-account">
         <h4 mat-line>{{ profile?.name || '&nbsp;' }}</h4>
         <a mat-line
-           href="">Log Out</a>
+           [href]="loginPath">Log Out</a>
         <div class="credentials-picture">
           <img matListAvatar
                [src]="profile?.picture || '/assets/images/placeholder_identity.png'"

--- a/angular/src/app/layout/layout.component.ts
+++ b/angular/src/app/layout/layout.component.ts
@@ -13,6 +13,7 @@ export class LayoutComponent implements OnInit {
 
   profile: Profile = null;
   realm: string;
+  loginPath: string;
 
   constructor(public loader: LoadingBarService,
               private router: Router,
@@ -28,6 +29,7 @@ export class LayoutComponent implements OnInit {
 
     this.activatedRoute.root.firstChild.params.subscribe((params) => {
       this.realm = params.realmId;
+      this.loginPath = `/api/v1alpha/${this.realm}/identity/login`;
     });
   }
 

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -29,9 +29,8 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
         </dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/e2e-tests/src/main/java/com/dnastack/ddap/common/page/ICLoginPage.java
+++ b/e2e-tests/src/main/java/com/dnastack/ddap/common/page/ICLoginPage.java
@@ -1,11 +1,16 @@
 package com.dnastack.ddap.common.page;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
+import java.net.URI;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+@Slf4j
 public class ICLoginPage implements HasNavBar {
 
     @Getter
@@ -15,6 +20,7 @@ public class ICLoginPage implements HasNavBar {
 
     public ICLoginPage(WebDriver driver) {
         this.driver = driver;
+        log.info("Testing if {} is an IC login page", driver.getCurrentUrl());
         driver.findElement(loginButton);
     }
 
@@ -23,4 +29,16 @@ public class ICLoginPage implements HasNavBar {
         return pageConstructor.apply(driver);
     }
 
+    public String getRealm() {
+        // FIXME when the realm name appears in the UI, we can get it from the UI element
+        // (at the time of this writing, the current realm name isn't mentioned in visible UI)
+        URI currentUrl = URI.create(driver.getCurrentUrl());
+        Pattern realmExtractor = Pattern.compile("/identity/v1alpha/([A-Za-z0-9_-]{3,40})/authorize");
+        Matcher matcher = realmExtractor.matcher(currentUrl.getPath());
+        if (matcher.matches()) {
+            return matcher.group(1);
+        } else {
+            throw new AssertionError("IC Login page path '" + currentUrl.getPath() + "' does not conform to expected format");
+        }
+    }
 }

--- a/e2e-tests/src/main/java/com/dnastack/ddap/common/page/NavBar.java
+++ b/e2e-tests/src/main/java/com/dnastack/ddap/common/page/NavBar.java
@@ -6,7 +6,9 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 public class NavBar {
     private WebDriver driver;
@@ -77,4 +79,28 @@ public class NavBar {
 
         return new NavBar(driver);
     }
+
+    private WebElement getRealmInput() {
+        return driver.findElement(By.xpath("//*[@data-se=\"realm-input\"]"));
+    }
+
+    public void setRealm(String targetRealm) {
+        WebElement realmInput = getRealmInput();
+        int oldRealmNameLength = getRealm().length();
+        for (int i = 0; i < oldRealmNameLength; i++) {
+            realmInput.sendKeys(Keys.BACK_SPACE);
+        }
+        realmInput.sendKeys(targetRealm, Keys.RETURN);
+    }
+
+    public String getRealm() {
+        WebElement realmInput = getRealmInput();
+        return realmInput.getAttribute("value");
+    }
+
+    public ICLoginPage logOut() {
+        driver.findElement(By.linkText("Log Out")).click();
+        return new ICLoginPage(driver);
+    }
+
 }

--- a/e2e-tests/src/main/java/com/dnastack/ddap/frontend/NavbarE2eTest.java
+++ b/e2e-tests/src/main/java/com/dnastack/ddap/frontend/NavbarE2eTest.java
@@ -1,23 +1,24 @@
 package com.dnastack.ddap.frontend;
 
-import static java.lang.String.format;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-
 import com.dnastack.ddap.common.AbstractFrontendE2eTest;
 import com.dnastack.ddap.common.page.ICLoginPage;
 import com.dnastack.ddap.common.page.IdentityPage;
 import com.dnastack.ddap.common.page.NavBar;
 import com.dnastack.ddap.common.page.NavBar.NavItem;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @SuppressWarnings("Duplicates")
 public class NavbarE2eTest extends AbstractFrontendE2eTest {
@@ -207,6 +208,29 @@ public class NavbarE2eTest extends AbstractFrontendE2eTest {
         final String usernameXpath = "//*[@data-se='nav-account']//h4[contains(text(), 'NCI Researcher')]";
 
         driver.findElement(By.xpath(usernameXpath)).getText();
+    }
+
+    @Test
+    public void realmSelectorShouldShowCurrentRealm() {
+        assertThat(ddapPage.getNavBar().getRealm(), is(REALM));
+    }
+
+    @Test
+    public void realmSelectorShouldBeAbleToChangeCurrentRealm() {
+        String otherRealm = "test_other_realm_" + System.currentTimeMillis();
+        assertThat("this test is pointless unless we start on a different realm than we're going to!",
+                ddapPage.getNavBar().getRealm(), is(not(otherRealm)));
+
+        ddapPage.getNavBar().setRealm(otherRealm);
+
+        assertThat(ddapPage.getNavBar().getRealm(), is(otherRealm));
+    }
+
+    @Test
+    public void logoutButtonShouldGoToIcLoginForCurrentRealm() {
+        ICLoginPage icLoginPage = ddapPage.getNavBar().logOut();
+
+        assertThat(icLoginPage.getRealm(), is(REALM));
     }
 
 }

--- a/src/main/java/com/dnastack/ddapfrontend/client/ic/IdentityConcentratorClient.java
+++ b/src/main/java/com/dnastack/ddapfrontend/client/ic/IdentityConcentratorClient.java
@@ -35,21 +35,20 @@ public class IdentityConcentratorClient {
             .build();
 
     public Mono<TokenResponse> exchangeAuthorizationCodeForTokens(String realm, URI redirectUri, String code) {
-        final UriTemplate template = new UriTemplate("{idpBaseUrl}/identity/v1alpha/{realm}/token" +
+        final UriTemplate template = new UriTemplate("/identity/v1alpha/{realm}/token" +
                 "?grant_type=authorization_code" +
                 "&code={code}" +
                 "&redirect_uri={redirectUri}" +
                 "&clientId={clientId}" +
                 "&clientSecret={clientSecret}");
         final Map<String, Object> variables = new HashMap<>();
-        variables.put("idpBaseUrl", idpBaseUrl);
         variables.put("realm", realm);
         variables.put("code", code);
         variables.put("redirectUri", redirectUri);
         variables.put("clientId", idpClientId);
         variables.put("clientSecret", idpClientSecret);
 
-        final URI uri = template.expand(variables);
+        final URI uri = idpBaseUrl.resolve(template.expand(variables));
         return webClient
                 .post()
                 .uri(uri)
@@ -68,20 +67,19 @@ public class IdentityConcentratorClient {
     }
 
     public Mono<TokenResponse> personaLogin(String realm, String scopes, String personaName) {
-        final UriTemplate template = new UriTemplate("{idpBaseUrl}/identity/v1alpha/{realm}/personas/{persona}" +
+        final UriTemplate template = new UriTemplate("/identity/v1alpha/{realm}/personas/{persona}" +
                 "?client_id={clientId}" +
                 "&client_secret={clientSecret}" +
                 "&scope={scopes}");
 
         final Map<String, Object> variables = new HashMap<>();
-        variables.put("idpBaseUrl", idpBaseUrl);
         variables.put("realm", realm);
         variables.put("persona", personaName);
         variables.put("clientId", idpClientId);
         variables.put("clientSecret", idpClientSecret);
         variables.put("scopes", scopes);
 
-        URI uri = template.expand(variables);
+        URI uri = idpBaseUrl.resolve(template.expand(variables));
         Mono<TokenResponse> scopedAccessTokenResponse = webClient
                 .get()
                 .uri(uri)
@@ -97,35 +95,38 @@ public class IdentityConcentratorClient {
     }
 
     private Mono<TokenResponse> getPersonaTokens(String realm, String personaName) {
-        final UriTemplate passportTemplate = new UriTemplate("{idpBaseUrl}/identity/v1alpha/{realm}/passport" +
+        final UriTemplate passportTemplate = new UriTemplate("/identity/v1alpha/{realm}/passport" +
                 "?persona={persona}" +
                 "&client_id={clientId}" +
                 "&client_secret={clientSecret}");
 
         final Map<String, Object> passportVariables = new HashMap<>();
-        passportVariables.put("idpBaseUrl", idpBaseUrl);
         passportVariables.put("realm", realm);
         passportVariables.put("persona", personaName);
         passportVariables.put("clientId", idpClientId);
         passportVariables.put("clientSecret", idpClientSecret);
         return webClient.get()
-                .uri(passportTemplate.expand(passportVariables))
+                .uri(idpBaseUrl.resolve(passportTemplate.expand(passportVariables)))
                 .exchange()
                 .flatMap(res -> res.bodyToMono(TokenResponse.class));
     }
 
     public URI getAuthorizeUrl(String realm, String state, String scopes, URI redirectUri) {
-        final UriTemplate template = new UriTemplate("{idpBaseUrl}/identity/v1alpha/{realm}/authorize?response_type=code&clientId={clientId}&redirect_uri={redirectUri}&state={state}&scope={scope}");
+        final UriTemplate template = new UriTemplate("/identity/v1alpha/{realm}/authorize" +
+                "?response_type=code" +
+                "&clientId={clientId}" +
+                "&redirect_uri={redirectUri}" +
+                "&state={state}" +
+                "&scope={scope}");
 
         final HashMap<String, Object> variables = new HashMap<>();
-        variables.put("idpBaseUrl", idpBaseUrl);
         variables.put("realm", realm);
         variables.put("clientId", idpClientId);
         variables.put("redirectUri", redirectUri);
         variables.put("state", state);
         variables.put("scope", scopes);
 
-        return template.expand(variables);
+        return idpBaseUrl.resolve(template.expand(variables));
     }
 
     /**
@@ -140,14 +141,13 @@ public class IdentityConcentratorClient {
      * @return the calculated absolute URI to send the client's browser to. Never null.
      */
     public URI getDirectLoginUrl(String realm, String state, String scopes, URI redirectUri, String provider) {
-        final UriTemplate template = new UriTemplate("{idpBaseUrl}/identity/v1alpha/{realm}/login/{provider}" +
+        final UriTemplate template = new UriTemplate("/identity/v1alpha/{realm}/login/{provider}" +
                 "?client_id={clientId}" +
                 "&redirect_uri={redirectUri}" +
                 "&scope={scopes}" +
                 "&state={state}");
 
         final HashMap<String, Object> variables = new HashMap<>();
-        variables.put("idpBaseUrl", idpBaseUrl);
         variables.put("realm", realm);
         variables.put("provider", provider);
         variables.put("clientId", idpClientId);
@@ -155,7 +155,7 @@ public class IdentityConcentratorClient {
         variables.put("scopes", scopes);
         variables.put("state", state);
 
-        return template.expand(variables);
+        return idpBaseUrl.resolve(template.expand(variables));
     }
 
     private static boolean contentTypeIsApplicationJson(ClientResponse response) {
@@ -189,20 +189,19 @@ public class IdentityConcentratorClient {
                                      String baseAccountAccessToken,
                                      String newAccountId,
                                      String newAccountLinkToken) {
-        final UriTemplate template = new UriTemplate("{idpBaseUrl}/identity/v1alpha/{realm}/accounts/{accountId}" +
+        final UriTemplate template = new UriTemplate("/identity/v1alpha/{realm}/accounts/{accountId}" +
                 "?client_id={clientId}" +
                 "&client_secret={clientSecret}" +
                 "&link_token={linkToken}");
 
         final Map<String, Object> variables = new HashMap<>();
-        variables.put("idpBaseUrl", idpBaseUrl);
         variables.put("realm", realm);
         variables.put("accountId", baseAccountId);
         variables.put("clientId", idpClientId);
         variables.put("clientSecret", idpClientSecret);
         variables.put("linkToken", newAccountLinkToken);
 
-        URI uri = template.expand(variables);
+        URI uri = idpBaseUrl.resolve(template.expand(variables));
         return webClient
                 .patch()
                 .uri(uri)


### PR DESCRIPTION
This change adds the first E2E tests for logout (back to IC login page) and switching realm. Instead of enshrining the "path starts with double slash" bug in test assertions, I have fixed the double slash bug (which was in IdentityConcentratorClient) as part of this task.