### PR TITLE
DISCO-2032 Enable resource deletion

### DIFF
--- a/angular/src/app/admin/resources/resource-detail/resource-detail.component.html
+++ b/angular/src/app/admin/resources/resource-detail/resource-detail.component.html
@@ -4,7 +4,8 @@
 <ddap-main>
   <p *ngIf="entity?.dto.ui.description">{{ entity?.dto.ui.description }}</p>
 
-  <ddap-json-panel [useTests]="true"
+  <ddap-json-panel *ngIf="entity"
+                   [useTests]="true"
                    [entityService]="entityService"
                    [entity]="entity">
   </ddap-json-panel>

--- a/angular/src/app/admin/resources/resources.service.ts
+++ b/angular/src/app/admin/resources/resources.service.ts
@@ -4,22 +4,17 @@ import { Observable } from 'rxjs/Observable';
 import { map, pluck } from 'rxjs/operators';
 
 import { environment } from '../../../environments/environment';
-import { HTTP_HEADERS } from '../../shared/HTTP_HEADERS';
 import { realmIdPlaceholder } from '../../shared/realm/realm.constant';
-import { ConfigModel } from '../shared/config.model';
-import { ConfigModificationObject } from '../shared/configModificationObject';
+import { ConfigEntityService } from '../shared/config-entity.service';
 import { EntityModel } from '../shared/entity.model';
-import { EntityService } from '../shared/entity.service';
-
-const headers = HTTP_HEADERS;
 
 @Injectable({
   providedIn: 'root',
 })
-export class ResourceService implements EntityService {
+export class ResourceService extends ConfigEntityService {
 
-  constructor(private http: HttpClient) {
-
+  constructor(http: HttpClient) {
+    super(http, 'resources', 'resources');
   }
 
   getAccessRequestToken(resourceId, viewId): Observable<any[]> {
@@ -30,35 +25,9 @@ export class ResourceService implements EntityService {
       );
   }
 
-  get(): Observable<Map<string, EntityModel>> {
-    return this.http.get<ConfigModel>(`${environment.damApiUrl}/${realmIdPlaceholder}/config`)
-      .pipe(
-        map(config => config.resources),
-        map(EntityModel.objectToMap)
-      );
-  }
-
   getResource(resourceName: string): Observable<EntityModel> {
     return this.get().pipe(
       map(resources => resources.get(resourceName))
     );
-  }
-
-  save(id: string, change: ConfigModificationObject): Observable<any> {
-    return this.http.post(`${environment.damApiUrl}/${realmIdPlaceholder}/config/resources/${id}`,
-      change,
-      {headers}
-    );
-  }
-
-  update(id: string, change: ConfigModificationObject): Observable<any> {
-    return this.http.put(`${environment.damApiUrl}/${realmIdPlaceholder}/config/resources/${id}`,
-      change,
-      {headers}
-    );
-  }
-
-  remove(id: string): Observable<any> {
-    throw new Error('Not yet implemented.');
   }
 }

--- a/angular/src/app/admin/shared/config-entity.service.ts
+++ b/angular/src/app/admin/shared/config-entity.service.ts
@@ -43,10 +43,8 @@ export class ConfigEntityService implements EntityService {
   }
 
   remove(id: string): Observable<any> {
-
     return this.http.delete(`${environment.damApiUrl}/${realmIdPlaceholder}/config/${this.typeNameInUrl}/${id}`,
       {headers}
     );
-
   }
 }


### PR DESCRIPTION
the `*ngIf` was needed because the test was clicking on the remove button before the entity was loaded. This should ultimately by resolved with an router "resolver", but so far, I've got troubles making it work with our http interceptor (getting the realmId from the url).

Journey tests PR:
https://github.com/DNAstack/ddap-journey-test/pull/8