### PR TITLE
DISCO-2179 make pop-up overlap access button

### DIFF
--- a/angular/src/app/shared/resource-view-item/resource-view-item.component.html
+++ b/angular/src/app/shared/resource-view-item/resource-view-item.component.html
@@ -51,7 +51,8 @@
 
 <mat-menu #appMenu="matMenu"
           class="access-menu"
-          [overlapTrigger]="true">
+          yPosition="above"
+          [overlapTrigger]="false">
   <div *ngIf="access; else error">
     <div class="flex flex--column vertical-center">
       <div class="flex vertical-center row">


### PR DESCRIPTION
@mbarkley I belive the issue here wasn't being menu below but not overlapping access button. In my opinion this solution looks better in general (small screen vs large screen) than the suggested solution.

![screenshot-localhost-8085-2019 04 29-11-39-07](https://user-images.githubusercontent.com/5015486/56888210-bf9c8500-6a73-11e9-88d1-b9bef5cdbfc2.png)
