### PR TITLE
DISCO-2239 navigate back to list view after edit for old-forms

### DIFF
--- a/angular/src/app/admin/shared/json-panel/json-panel.component.ts
+++ b/angular/src/app/admin/shared/json-panel/json-panel.component.ts
@@ -146,6 +146,8 @@ export class JsonPanelComponent implements OnChanges, OnDestroy {
 
         this.state = ViewState.Viewing;
         this.setEditorMode('view');
+
+        this.navigateBackTolistView();
       })
     );
   }
@@ -165,12 +167,16 @@ export class JsonPanelComponent implements OnChanges, OnDestroy {
     this.state = ViewState.Submitting;
     this.entityService.remove(this.entity.name)
       .subscribe(() => {
-      const routeToListView = this.router.url.substring(0, this.router.url.lastIndexOf('/'));
-        this.router.navigate([routeToListView]);
+        this.navigateBackTolistView();
       }, e => {
         this.state = ViewState.Viewing;
         this.error = e.error;
       });
+  }
+
+  private navigateBackTolistView() {
+    const routeToListView = this.router.url.substring(0, this.router.url.lastIndexOf('/'));
+    this.router.navigate([routeToListView]);
   }
 
   private getTestDto() {


### PR DESCRIPTION
The error manifests itself only with old forms, so the affected forms are Service templates and Access policies. This is easy fix, forcing to reload by navigating back to list view