### PR TITLE
Dataset URLs for Workflow Execution are now Base64 encoded for transfer

### DIFF
--- a/angular/src/app/workflows/dataset.service.ts
+++ b/angular/src/app/workflows/dataset.service.ts
@@ -17,7 +17,8 @@ export class DatasetService {
               private errorHandler: ErrorHandlerService) { }
 
   fetchDataset(url: string): Observable<Dataset> {
-    return this.http.get<Dataset>(`${environment.ddapApiUrl}/${realmIdPlaceholder}/dataset?dataset_url=${url}`)
+    const base64Url = btoa(url).replace('///g', '_').replace('/+/g', '-');
+    return this.http.get<Dataset>(`${environment.ddapApiUrl}/${realmIdPlaceholder}/dataset?dataset_url=${base64Url}`)
       .pipe(
         this.errorHandler.notifyOnError(`Can't fetch dataset list.`)
       );

--- a/src/main/java/com/dnastack/ddap/explore/dataset/controller/DatasetController.java
+++ b/src/main/java/com/dnastack/ddap/explore/dataset/controller/DatasetController.java
@@ -13,9 +13,6 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static com.dnastack.ddap.common.security.UserTokenCookiePackager.CookieKind;

--- a/src/main/java/com/dnastack/ddap/explore/dataset/controller/DatasetController.java
+++ b/src/main/java/com/dnastack/ddap/explore/dataset/controller/DatasetController.java
@@ -13,6 +13,9 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static com.dnastack.ddap.common.security.UserTokenCookiePackager.CookieKind;
@@ -41,7 +44,8 @@ public class DatasetController {
                                             @RequestParam(value = "access_token", required = false) String accessToken,
                                             ServerHttpRequest request,
                                             @PathVariable String realm) {
-        return getDatasetResult(datasetUrl, accessToken, request, realm);
+        String decodedDatasetUrl = new String(Base64.getUrlDecoder().decode(datasetUrl));
+        return getDatasetResult(decodedDatasetUrl, accessToken, request, realm);
     }
 
     private Mono<DatasetResult> getDatasetResult(String datasetUrl, String token, ServerHttpRequest request, String realm) {


### PR DESCRIPTION
>The frontend now base64 encodes dataset_url before invoking backend. A manual substitution of base64 results is done to comply with URL safe base64 encoding (AFAIK javascript doesn't have a built-in way to do this).
>Backend now base64 decodes the backend URL using Base64.URLDecoder


OK here's attempt #2 at making this happen. I've greatly simplified the process by (at Max's suggestion) using URL-safe base64 encoding/decoding. According to the top stackoverflow result, there's not an out-of-the-box way to do this in javascript, so I'm doing a string substitution on the 2 characters which are spec'd differently between the base64 encoding schemes. I'm happy to make this more robust if requested.